### PR TITLE
Fix README broker command typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ The Configurations are:
   ``` C++
   #include <AlpacaBrokerCommands.h>
   ....
-  int fractionable = brokerCommand(IS_ASSERT_FRACTIONABLE, Asset);
-  int shortable = brokerCommand(IS_ASSERT_SHORTABLE, Asset);
-  int easyToBorrow = brokerCommand(IS_ASSERT_EASY_TO_BORROW, Asset);
-  int marginable = brokerCommand(IS_ASSERT_EASY_TO_MARGINABLE, Asset);
+  int fractionable = brokerCommand(IS_ASSET_FRACTIONABLE, Asset);
+  int shortable = brokerCommand(IS_ASSET_SHORTABLE, Asset);
+  int easyToBorrow = brokerCommand(IS_ASSET_EASY_TO_BORROW, Asset);
+  int marginable = brokerCommand(IS_ASSET_EASY_TO_MARGINABLE, Asset);
   ```
 
 * Set Historical Bar Adjustment 


### PR DESCRIPTION
## Summary
- fix typos for broker command names in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6844492a22d4833396166d969468986f