### PR TITLE
Add configurable logging level dialog

### DIFF
--- a/alpaca_zorro_plugin/SettingsDialog.cpp
+++ b/alpaca_zorro_plugin/SettingsDialog.cpp
@@ -1,0 +1,48 @@
+#include "stdafx.h"
+#include "SettingsDialog.h"
+#include "resource.h"
+#include "config.h"
+#include "global.h"
+
+namespace {
+    Config &s_config = Config::get();
+}
+
+INT_PTR CALLBACK SettingsDlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+{
+    switch (message)
+    {
+    case WM_INITDIALOG:
+    {
+        HWND hCombo = GetDlgItem(hDlg, IDC_LOG_LEVEL);
+        const char* levels[] = { "Off", "Error", "Warn", "Info", "Debug", "Trace" };
+        for (int i = 0; i < 6; ++i)
+        {
+            SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM)levels[i]);
+        }
+        SendMessage(hCombo, CB_SETCURSEL, s_config.logLevel, 0);
+        return (INT_PTR)TRUE;
+    }
+    case WM_COMMAND:
+        switch (LOWORD(wParam))
+        {
+        case IDOK:
+        {
+            int sel = (int)SendMessage(GetDlgItem(hDlg, IDC_LOG_LEVEL), CB_GETCURSEL, 0, 0);
+            PostThreadMessage(g_mainThreadId, WM_LOG_LEVEL_CHANGE, sel, 0);
+            auto &global = zorro::Global::get();
+            if (global.handle_)
+            {
+                PostMessage(global.handle_, WM_APP + 3, 0, 0);
+            }
+            EndDialog(hDlg, IDOK);
+            return (INT_PTR)TRUE;
+        }
+        case IDCANCEL:
+            EndDialog(hDlg, IDCANCEL);
+            return (INT_PTR)TRUE;
+        }
+        break;
+    }
+    return (INT_PTR)FALSE;
+}

--- a/alpaca_zorro_plugin/SettingsDialog.h
+++ b/alpaca_zorro_plugin/SettingsDialog.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <windows.h>
+
+constexpr UINT WM_LOG_LEVEL_CHANGE = WM_APP + 2;
+
+extern DWORD g_mainThreadId;
+
+INT_PTR CALLBACK SettingsDlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);

--- a/alpaca_zorro_plugin/alpaca_zorro_plugin.rc
+++ b/alpaca_zorro_plugin/alpaca_zorro_plugin.rc
@@ -44,6 +44,21 @@ END
 
 #endif    // APSTUDIO_INVOKED
 
+/////////////////////////////////////////////////////////////////////////////
+//
+// Dialog
+//
+
+IDD_SETTINGS_DIALOG DIALOGEX 0, 0, 176, 95
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Alpaca Settings"
+FONT 8, "MS Shell Dlg", 0, 0, 0x0
+BEGIN
+    LTEXT           "Logging Level:",-1,7,14,60,8
+    COMBOBOX        IDC_LOG_LEVEL,73,12,96,80,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    DEFPUSHBUTTON   "OK",IDOK,38,65,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,95,65,50,14
+END
 
 /////////////////////////////////////////////////////////////////////////////
 //

--- a/alpaca_zorro_plugin/dllmain.cpp
+++ b/alpaca_zorro_plugin/dllmain.cpp
@@ -1,19 +1,22 @@
 // dllmain.cpp : Defines the entry point for the DLL application.
 #include "stdafx.h"
 
-BOOL APIENTRY DllMain( HMODULE hModule,
+extern HMODULE g_hModule;
+
+BOOL APIENTRY DllMain(HMODULE hModule,
                        DWORD  ul_reason_for_call,
-                       LPVOID lpReserved
-					 )
+                       LPVOID lpReserved)
 {
-	switch (ul_reason_for_call)
-	{
-	case DLL_PROCESS_ATTACH:
-	case DLL_THREAD_ATTACH:
-	case DLL_THREAD_DETACH:
-	case DLL_PROCESS_DETACH:
-		break;
-	}
-	return TRUE;
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+        g_hModule = hModule;
+        break;
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
 }
 

--- a/alpaca_zorro_plugin/resource.h
+++ b/alpaca_zorro_plugin/resource.h
@@ -3,12 +3,15 @@
 // Used by alpaca_zorro_plugin.rc
 
 // Next default values for new objects
-// 
+//
+#define IDD_SETTINGS_DIALOG             101
+#define IDC_LOG_LEVEL                   1001
+
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        101
+#define _APS_NEXT_RESOURCE_VALUE        102
 #define _APS_NEXT_COMMAND_VALUE         40001
-#define _APS_NEXT_CONTROL_VALUE         1001
+#define _APS_NEXT_CONTROL_VALUE         1002
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif


### PR DESCRIPTION
## Summary
- Launch a settings dialog on F2 in a dedicated thread to adjust logging level
- Trigger Zorro callback via `WM_APP+3` and process log-level updates centrally instead of polling in each broker API function
- Register a broker callback that applies posted log-level changes

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: SDKDDKVer.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689de5708f788333ba81fc0e52385766